### PR TITLE
Fix code scanning alert no. 21: Type confusion through parameter tampering

### DIFF
--- a/fixtures/flight-esm/server/region.js
+++ b/fixtures/flight-esm/server/region.js
@@ -125,6 +125,10 @@ if (process.env.NODE_ENV === 'development') {
     try {
       res.set('Content-type', 'application/json');
       let requestedFilePath = req.query.name;
+      if (typeof requestedFilePath !== 'string') {
+        res.status(400).send("Bad request");
+        return;
+      }
 
       let isCompiledOutput = false;
       if (requestedFilePath.startsWith('file://')) {


### PR DESCRIPTION
Fixes [https://github.com/akaday/react/security/code-scanning/21](https://github.com/akaday/react/security/code-scanning/21)

To fix the problem, we need to ensure that the `req.query.name` parameter is a string before using it. If it is not a string, we should handle it appropriately, such as by returning an error response. This can be done by adding a type check for `req.query.name` and ensuring it is a string before proceeding with the rest of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
