### PR TITLE
Fix code scanning alert no. 19: Type confusion through parameter tampering

### DIFF
--- a/fixtures/flight/server/region.js
+++ b/fixtures/flight/server/region.js
@@ -246,6 +246,10 @@ if (process.env.NODE_ENV === 'development') {
     try {
       res.set('Content-type', 'application/json');
       let requestedFilePath = req.query.name;
+      if (typeof requestedFilePath !== 'string') {
+        res.status(400).send('Bad request');
+        return;
+      }
 
       let isCompiledOutput = false;
       if (requestedFilePath.startsWith('file://')) {


### PR DESCRIPTION
Fixes [https://github.com/akaday/react/security/code-scanning/19](https://github.com/akaday/react/security/code-scanning/19)

To fix the problem, we need to ensure that the `req.query.name` parameter is a string before using it. If it is not a string, we should handle it appropriately, such as by returning an error response. This can be done by adding a type check for `requestedFilePath` before it is used.

- Add a type check for `requestedFilePath` to ensure it is a string.
- If `requestedFilePath` is not a string, return a 400 Bad Request response.
- This change should be made in the `fixtures/flight/server/region.js` file, specifically around line 248 where `requestedFilePath` is assigned.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
