### PR TITLE
Fix code scanning alert no. 19: Type confusion through parameter tampering

### DIFF
--- a/fixtures/flight/server/region.js
+++ b/fixtures/flight/server/region.js
@@ -246,6 +246,10 @@ if (process.env.NODE_ENV === 'development') {
     try {
       res.set('Content-type', 'application/json');
       let requestedFilePath = req.query.name;
+      if (typeof requestedFilePath !== 'string') {
+        res.status(400).send("Bad request");
+        return;
+      }
 
       let isCompiledOutput = false;
       if (requestedFilePath.startsWith('file://')) {


### PR DESCRIPTION
Fixes [https://github.com/akaday/react/security/code-scanning/19](https://github.com/akaday/react/security/code-scanning/19)

To fix the problem, we need to ensure that `requestedFilePath` is always a string before performing any operations on it. This can be done by checking the type of `req.query.name` and handling the case where it is an array. If it is an array, we can either reject the request or convert the array to a string in a safe manner.

The best way to fix the problem without changing existing functionality is to add a type check for `req.query.name` and handle the case where it is not a string. We will modify the code in `fixtures/flight/server/region.js` to include this type check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
